### PR TITLE
Swap to use steinbacher goose fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.6
 MAINTAINER ivan@fraixed.es
 
-RUN go get bitbucket.org/liamstask/goose/cmd/goose && mkdir /db
+RUN go get github.com/steinbacher/goose/cmd/goose && mkdir /db
 WORKDIR /
 
 VOLUME ["/db"]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Docker Goose
 ============
 
-Docker image with [Golang](https://golang.org/) [Goose Database migration tool](https://bitbucket.org/liamstask/goose)
+Docker image with [Golang](https://golang.org/) [Goose Database migration tool](https://github.com/steinbacher/goose)
 
 ## Why
 


### PR DESCRIPTION
Swapping to https://github.com/steinbacher/goose/ because I started to use https://github.com/CloudCom/goose for being able to the [omitting drivers feature](https://github.com/CloudCom/goose#omitting-drivers) because allow to exclude drivers as SQLite which require CGO and I need to run goose in alpine containers which doens't bring libc out of the box, however [I opened a PR to fix CloudCom fork and it turned to be unmaintained](https://github.com/CloudCom/goose/pull/38)
